### PR TITLE
build against libgomp on linux

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e754266e5dfcb761fd2d033041e225cf5ea0570e0587af5d56cc02ed00589820
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
   script:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,7 +36,9 @@ requirements:
     - libblas
     - libcint
     - libxc-c >=6,<8
-    - llvm-openmp
+    - if: linux
+      then: libgomp
+      else: llvm-openmp
     - make
     - pip
     - python


### PR DESCRIPTION
This PR compiles pyscf against libgomp rather than llvm-openmp on linux, following the [recommendations](https://conda-forge.org/docs/maintainer/knowledge_base/#openmp) in the knowledge base.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
