### PR TITLE
restore microarch build number

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   version: "2.13.0"
   touch_is_freethreading: ${{ is_freethreading }}
-  build_num: 0
+  build_num: 1
   mlevel: ${{ (microarch_level | int) if microarch_level else 0 }}
   use_fast_math: ${{ linux and x86_64 and match(c_stdlib_version, ">=2.28") }}
 
@@ -14,7 +14,7 @@ source:
   sha256: b0f22880d918d3ae7cf6abb5629c457d2e58a572e22695ee849b17efa05c57d2
 
 build:
-  number: 0
+  number: ${{ ( (build_num | int) + 100 * (mlevel | int) + (1000 if use_fast_math else 0) ) }}
   python:
     version_independent: true
   skip:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


Unfortunately, [regro-cf-autotick-bot](https://github.com/conda-forge/pyscf-feedstock/commits?author=regro-cf-autotick-bot) removed the expression that calculates the build number as a function of microarch level. I wonder if there's a way to stop that? Adding it back in manually for now.