### PR TITLE
microarch level string/int nonsense

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   version: "2.13.0"
   touch_is_freethreading: ${{ is_freethreading }}
-  build_num: 2
+  build_num: 10000
   mlevel: ${{ (microarch_level | int) if microarch_level else 0 }}
   use_fast_math: ${{ linux and x86_64 and match(c_stdlib_version, ">=2.28") }}
 
@@ -28,7 +28,7 @@ build:
         - cp $SRC_DIR/pyscf/lib/cmake_user_inc_examples/cmake.user.inc-gnu $SRC_DIR/pyscf/lib/cmake.arch.inc
         # need to link libm for -ffast-math
         - echo "link_libraries(m)" >> $SRC_DIR/pyscf/lib/cmake.arch.inc
-    - if: (microarch_level == 4)
+    - if: (mlevel == 4)
       then:
         # manually add the appropriate flags so we can cross compile for v4
         - export CFLAGS="${CFLAGS} -march=x86-64-v4"
@@ -54,8 +54,8 @@ requirements:
     - setuptools
     # following the trick in graph-tool-feedstock
     # to cross-compile for v4
-    - if: unix and x86_64 and ( microarch_level < 4)
-      then: x86_64-microarch-level ==${{ microarch_level }}
+    - if: unix and x86_64 and (mlevel < 4)
+      then: x86_64-microarch-level ==${{ mlevel }}
   host:
     - libblas
     - libcint
@@ -74,14 +74,14 @@ requirements:
     - python
     - scipy >=0.19,!=1.5.0,!=1.5
     - setuptools
-    - if: unix and x86_64 and (microarch_level == 4)
-      then: _x86_64-microarch-level >=${{ microarch_level }}
+    - if: unix and x86_64 and (mlevel == 4)
+      then: _x86_64-microarch-level >=${{ mlevel }}
   run_constraints:
     - pyberny >=0.6.2
     - geometric >=0.9.7.2
 
 tests:
-  - if: (microarch_level != 4)
+  - if: (mlevel != 4)
     then:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   version: "2.13.0"
   touch_is_freethreading: ${{ is_freethreading }}
-  build_num: 10000
+  build_num: 3
   mlevel: ${{ (microarch_level | int) if microarch_level else 0 }}
   use_fast_math: ${{ linux and x86_64 and match(c_stdlib_version, ">=2.28") }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


For some unfortunate reason, PR #60 caused the variable `microarch_level` to be a string rather than an int, causing comparisons like `    - if: unix and x86_64 and (microarch_level < 4)` to fail. This is now fixed, and I have verified that the correct `-march` flags are passed to the compiler.

The build number is bumped to 10000.

I am going to wait for feedback before merging this.